### PR TITLE
修复通过 ModulePreferenceFragment 创建的 prefs 无法被宿主读取的问题

### DIFF
--- a/yukihookapi-core/src/main/java/com/highcapable/yukihookapi/hook/xposed/prefs/ui/ModulePreferenceFragment.kt
+++ b/yukihookapi-core/src/main/java/com/highcapable/yukihookapi/hook/xposed/prefs/ui/ModulePreferenceFragment.kt
@@ -66,7 +66,8 @@ abstract class ModulePreferenceFragment : PreferenceFragmentCompat(), SharedPref
      * 获取应用默认的 [SharedPreferences]
      * @return [SharedPreferences]
      */
-    private val currentSharedPrefs get() = PreferenceManager.getDefaultSharedPreferences(currentActivity)
+    @Suppress("DEPRECATION", "WorldReadableFiles")
+    private val currentSharedPrefs get() = currentActivity.getSharedPreferences(prefsName, Context.MODE_WORLD_READABLE)
 
     @CallSuper
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {


### PR DESCRIPTION
修复 #86 

修改了 ModulePreferenceFragment 中获取 currentSharedPrefs 的实现。当 prefs 文件不存在时，获取 currentSharedPrefs 时将会创建宿主可读的 prefs 文件。

另：目前的 currentSharedPrefs 实现方式有什么特殊考量吗