### PR TITLE
docs: update Gradle dependencies syntax

### DIFF
--- a/docs-source/src/en/guide/quick-start.md
+++ b/docs-source/src/en/guide/quick-start.md
@@ -113,8 +113,8 @@ Add repositories in your project `build.gradle.kts`.
 repositories {
     google()
     mavenCentral()
-    // Must be added when used as an Xposed Module, otherwise optional
-    maven { url("https://api.xposed.info/") }
+    // Must be added when used as an Xposed Module, otherwise optional 
+    maven("https://api.xposed.info/")
 }
 ```
 
@@ -185,7 +185,7 @@ repositories {
     google()
     mavenCentral()
     // Must be added when used as an Xposed Module, otherwise optional
-    maven { url("https://api.xposed.info/") }
+    maven("https://api.xposed.info/")
 }
 ```
 

--- a/docs-source/src/zh-cn/guide/quick-start.md
+++ b/docs-source/src/zh-cn/guide/quick-start.md
@@ -114,7 +114,7 @@ repositories {
     google()
     mavenCentral()
     // 作为 Xposed 模块使用务必添加，其它情况可选
-    maven { url("https://api.xposed.info/") }
+    maven("https://api.xposed.info/")
 }
 ```
 
@@ -185,7 +185,7 @@ repositories {
     google()
     mavenCentral()
     // 作为 Xposed 模块使用务必添加，其它情况可选
-    maven { url("https://api.xposed.info/") }
+    maven("https://api.xposed.info/")
 }
 ```
 


### PR DESCRIPTION
maven { url("https://api.xposed.info/") }
这种写法好像是错误的或者是已经更换了,现在这样写android stduio会报错